### PR TITLE
Set up local docker build for API server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: api-server:latest
     command: [
       "/app/api/build/server",
-      "--config=/app/api/config/prod.yaml"
+      "--config=/app/api/config/local-docker.yaml"
     ]
     depends_on:
       - api-database


### PR DESCRIPTION
To build the api image in local docker and do health check, do:
1. Create a new file under api/config called: local-docker.yaml and add below
```
database_uri: "postgresql://postgres:@api-database:5432/postgres?sslmode=disable"
server:
  port: 20005 
  env: local
```
3. Build the image with: docker compose build api
4. Deploy the image to local docker with: docker compose up api
5. To check the health: In another terminal, do `curl -X GET http://localhost:20005/health`