### PR TITLE
Adds AWS SSO Auth for local deployments

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -63,7 +63,10 @@ func main() {
 		logger.Fatalf("Failed to connect to the blockchain provider, error: %v", err)
 	}
 
-	kmsClient := keymanagement.NewKmsClient(cfg.Region)
+	kmsClient, err := keymanagement.NewKmsClient(cfg.Region, cfg.SSOProfile)
+	if err != nil {
+		logger.Fatalf("Failed to create kms client: %v", err)
+	}
 
 	awsSession, err := session.NewSession(&aws.Config{
 		Region: aws.String(cfg.Region),

--- a/api/cmd/streamer/main.go
+++ b/api/cmd/streamer/main.go
@@ -42,7 +42,11 @@ func main() {
 
 	apiGateway := gateway.NewApiHttpGateway(cfg.ApiGatewayUrl)
 
-	kmsClient := keymanagement.NewKmsClient(cfg.Region)
+	kmsClient, err := keymanagement.NewKmsClient(cfg.Region, cfg.SSOProfile)
+	if err != nil {
+		logger.Fatalf("Failed to create KMS client: %v", err)
+	}
+
 	encryptedBytes, err := kmsClient.Encrypt([]byte(cfg.AdminAuthMessage), cfg.AuthKeyId)
 	if err != nil {
 		logger.Fatalf("Failed to encrypt with kms: %v", err)

--- a/api/config/dev.yaml
+++ b/api/config/dev.yaml
@@ -1,2 +1,2 @@
 env: dev
-egion: us-west-2
+region: us-west-2

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -24,6 +24,7 @@ type AppConfig struct {
 	Protocol            *ProtocolConfig `yaml:"protocol"`
 	GrpcWeb3Gateway     string          `yaml:"grpc_web3_gateway"`
 	StoryBlocksRegistry string          `yaml:"story_blocks_registry"`
+	SSOProfile				  string					`yaml:"sso_profile"`
 }
 
 type StreamerConfig struct {
@@ -34,6 +35,7 @@ type StreamerConfig struct {
 	AdminAuthMessage     string `yaml:"admin_auth_message"`
 	AuthKeyId            string `yaml:"auth_key_id"`
 	OrchestratorContract string `yaml:"orchestrator_contract"`
+	SSOProfile           string `yaml:"sso_profile"`
 }
 
 type ProtocolConfig struct {


### PR DESCRIPTION
As a best practice, Story Protocol will be moving to AWS SSO for better role delegation. As such, instead of relying on AWS keys and secrets, or user auth, we should be able to conduct local tests and SDK interactions natively with SSO.

This PR adds support for a new YAML configuration, "sso_profile", which if provided will allow the AWS SDK to authenticate with your temporary SSO login credentials instead.