### PR TITLE
Fixed a few issues to the alpha API

### DIFF
--- a/api/internal/entity/v0-alpha/hook.go
+++ b/api/internal/entity/v0-alpha/hook.go
@@ -1,5 +1,7 @@
 package v0alpha
 
+import "github.com/project-nova/backend/pkg/utils"
+
 type Hook struct {
 	ID           string `json:"id,omitempty"`
 	ModuleId     string `json:"moduleId,omitempty"`
@@ -57,7 +59,7 @@ func (h *HookTheGraphAlpha) ToHook() *Hook {
 		ModuleId:     h.ModuleId,
 		HookType:     h.Type,
 		RegistryKey:  h.RegistryKey,
-		RegisteredAt: h.BlockTimestamp,
+		RegisteredAt: utils.TimestampInSecondsToISO8601(h.BlockTimestamp),
 		TxHash:       h.TxHash,
 	}
 }

--- a/api/internal/entity/v0-alpha/hook.go
+++ b/api/internal/entity/v0-alpha/hook.go
@@ -6,7 +6,7 @@ type Hook struct {
 	ID           string `json:"id,omitempty"`
 	ModuleId     string `json:"moduleId,omitempty"`
 	Interface    string `json:"interface,omitempty"`
-	HookType     int64  `json:"hookType,omitempty"`
+	HookType     int64  `json:"hookType"`
 	RegistryKey  string `json:"registryKey,omitempty"`
 	RegisteredAt string `json:"registeredAt,omitempty"`
 	TxHash       string `json:"txHash,omitempty"`

--- a/api/internal/entity/v0-alpha/ipasset.go
+++ b/api/internal/entity/v0-alpha/ipasset.go
@@ -1,5 +1,7 @@
 package v0alpha
 
+import "github.com/project-nova/backend/pkg/utils"
+
 type IPAsset struct {
 	ID          string `json:"id,omitempty"`
 	Name        string `json:"name,omitempty"`
@@ -79,7 +81,7 @@ func (i *IPAssetTheGraphAlpha) ToIPAsset() *IPAsset {
 		Owner:       i.Owner,
 		MediaUrl:    i.MediaUrl,
 		ContentHash: []byte(i.ContentHash),
-		CreatedAt:   i.BlockTimestamp,
+		CreatedAt:   utils.TimestampInSecondsToISO8601(i.BlockTimestamp),
 		TxHash:      i.TxHash,
 	}
 }

--- a/api/internal/entity/v0-alpha/ipasset.go
+++ b/api/internal/entity/v0-alpha/ipasset.go
@@ -9,7 +9,7 @@ import (
 type IPAsset struct {
 	ID          string `json:"id,omitempty"`
 	Name        string `json:"name,omitempty"`
-	Type        int64  `json:"type,omitempty"`
+	Type        int64  `json:"type"`
 	IPOrgId     string `json:"ipOrgId,omitempty"`
 	Owner       string `json:"owner,omitempty"`
 	MediaUrl    string `json:"mediaUrl,omitempty"`

--- a/api/internal/entity/v0-alpha/ipasset.go
+++ b/api/internal/entity/v0-alpha/ipasset.go
@@ -1,6 +1,10 @@
 package v0alpha
 
-import "github.com/project-nova/backend/pkg/utils"
+import (
+	"strconv"
+
+	"github.com/project-nova/backend/pkg/utils"
+)
 
 type IPAsset struct {
 	ID          string `json:"id,omitempty"`
@@ -51,7 +55,7 @@ type IPAssetTheGraphAlpha struct {
 	IPOrgAssetId   string `json:"ipOrgAssetId"`
 	Owner          string `json:"owner"`
 	Name           string `json:"name"`
-	IPAssetType    int64  `json:"ipAssetType"`
+	IPAssetType    string `json:"ipAssetType"`
 	ContentHash    string `json:"contentHash"`
 	MediaUrl       string `json:"mediaUrl"`
 	BlockNumber    string `json:"blockNumber"`
@@ -73,10 +77,11 @@ func (i *IpAssetTheGraphAlphaResponse) ToIPAssets() []*IPAsset {
 }
 
 func (i *IPAssetTheGraphAlpha) ToIPAsset() *IPAsset {
+	ipAssetType, _ := strconv.ParseInt(i.IPAssetType, 10, 64)
 	return &IPAsset{
 		ID:          i.IPAssetId,
 		Name:        i.Name,
-		Type:        i.IPAssetType,
+		Type:        ipAssetType,
 		IPOrgId:     i.IPOrgId,
 		Owner:       i.Owner,
 		MediaUrl:    i.MediaUrl,

--- a/api/internal/entity/v0-alpha/iporg.go
+++ b/api/internal/entity/v0-alpha/iporg.go
@@ -1,5 +1,7 @@
 package v0alpha
 
+import "github.com/project-nova/backend/pkg/utils"
+
 type IPOrg struct {
 	ID           string   `json:"id,omitempty"`
 	Name         string   `json:"name,omitempty"`
@@ -60,7 +62,7 @@ func (i *IPOrgTheGraphAlpha) ToIPOrg() *IPOrg {
 		BaseUri:      i.BaseURI,
 		ContractUri:  i.ContractURI,
 		IPAssetTypes: i.IPAssetTypes,
-		CreatedAt:    i.BlockTimestamp,
+		CreatedAt:    utils.TimestampInSecondsToISO8601(i.BlockTimestamp),
 		TxHash:       i.TxHash,
 	}
 }

--- a/api/internal/entity/v0-alpha/license.go
+++ b/api/internal/entity/v0-alpha/license.go
@@ -11,7 +11,7 @@ type License struct {
 	Licensor        string   `json:"licensor,omitempty"`
 	Revoker         string   `json:"revoker,omitempty"`
 	IPOrgId         string   `json:"ipOrgId,omitempty"`
-	LicenseeType    int      `json:"licenseeType,omitempty"`
+	LicenseeType    int      `json:"licenseeType"`
 	IPAssetId       string   `json:"ipAssetId,omitempty"`
 	ParentLicenseId string   `json:"parentLicenseId,omitempty"`
 	TermIds         []string `json:"termIds,omitempty"`

--- a/api/internal/entity/v0-alpha/license.go
+++ b/api/internal/entity/v0-alpha/license.go
@@ -1,5 +1,9 @@
 package v0alpha
 
+import (
+	"github.com/project-nova/backend/pkg/utils"
+)
+
 type License struct {
 	ID              string   `json:"id,omitempty"`
 	IsCommercial    bool     `json:"isCommercial,omitempty"`
@@ -62,6 +66,7 @@ func (l *LicenseTheGraphAlphaResponse) ToLicenses() []*License {
 }
 
 func (l *LicenseRegistryTheGraphAlpha) ToLicense() *License {
+
 	return &License{
 		ID:              l.LicenseId,
 		IsCommercial:    l.IsCommercial,
@@ -74,7 +79,7 @@ func (l *LicenseRegistryTheGraphAlpha) ToLicense() *License {
 		ParentLicenseId: l.ParentLicenseId,
 		TermIds:         l.TermIds,
 		TermsData:       l.TermsData,
-		CreatedAt:       l.BlockTimestamp,
+		CreatedAt:       utils.TimestampInSecondsToISO8601(l.BlockTimestamp),
 		TxHash:          l.TxHash,
 	}
 }

--- a/api/internal/entity/v0-alpha/options.go
+++ b/api/internal/entity/v0-alpha/options.go
@@ -15,6 +15,8 @@ package v0alpha
 	}
 */
 type QueryOptions struct {
-	Offset int `json:"offset,omitempty"`
-	Limit  int `json:"limit,omitempty"`
+	Pagination struct {
+		Offset int `json:"offset,omitempty"`
+		Limit  int `json:"limit,omitempty"`
+	} `json:"pagination,omitempty"`
 }

--- a/api/internal/entity/v0-alpha/options.go
+++ b/api/internal/entity/v0-alpha/options.go
@@ -16,7 +16,7 @@ package v0alpha
 */
 type QueryOptions struct {
 	Pagination struct {
-		Offset int `json:"offset,omitempty"`
-		Limit  int `json:"limit,omitempty"`
-	} `json:"pagination,omitempty"`
+		Offset int `json:"offset"`
+		Limit  int `json:"limit"`
+	} `json:"pagination"`
 }

--- a/api/internal/entity/v0-alpha/relationship.go
+++ b/api/internal/entity/v0-alpha/relationship.go
@@ -1,5 +1,7 @@
 package v0alpha
 
+import "github.com/project-nova/backend/pkg/utils"
+
 type Relationship struct {
 	ID           string `json:"id,omitempty"`
 	Type         string `json:"type,omitempty"`
@@ -79,7 +81,7 @@ func (r *RelationshipTheGraphAlpha) ToRelationship() *Relationship {
 		SrcTokenId:   r.SrcId,
 		DstContract:  r.DstAddress,
 		DstTokenId:   r.DstId,
-		RegisteredAt: r.BlockTimestamp,
+		RegisteredAt: utils.TimestampInSecondsToISO8601(r.BlockTimestamp),
 		TxHash:       r.TxHash,
 	}
 }

--- a/api/internal/entity/v0-alpha/transaction.go
+++ b/api/internal/entity/v0-alpha/transaction.go
@@ -1,5 +1,7 @@
 package v0alpha
 
+import "github.com/project-nova/backend/pkg/utils"
+
 type Transaction struct {
 	ID           string       `json:"id,omitempty"`
 	TxHash       string       `json:"txHash,omitempty"`
@@ -93,6 +95,6 @@ func (t *TransactionTheGraphAlpha) ToTransaction() *Transaction {
 		ResourceType: ResourceType(t.ResourceType),
 		ActionType:   ActionType(t.ActionType),
 		Initiator:    t.Initiator,
-		CreatedAt:    t.BlockTimestamp,
+		CreatedAt:    utils.TimestampInSecondsToISO8601(t.BlockTimestamp),
 	}
 }

--- a/api/internal/handler/protocol_handler_alpha.go
+++ b/api/internal/handler/protocol_handler_alpha.go
@@ -49,6 +49,11 @@ func (p *AlphaProtocolHandler) GetIpOrgHandler(c *gin.Context) {
 		return
 	}
 
+	if ipOrg == nil {
+		c.JSON(http.StatusNotFound, ErrorMessage("Not found"))
+		return
+	}
+
 	c.JSON(http.StatusOK, v0alpha_entity.GetIpOrgResponse{
 		IPOrg: ipOrg,
 	})
@@ -61,6 +66,11 @@ func (p *AlphaProtocolHandler) GetIpAssetHandler(c *gin.Context) {
 	if err != nil {
 		logger.Errorf("Failed to get ipasset: %v", err)
 		c.JSON(http.StatusInternalServerError, ErrorMessage("Internal server error"))
+		return
+	}
+
+	if ipAsset == nil {
+		c.JSON(http.StatusNotFound, ErrorMessage("Not found"))
 		return
 	}
 
@@ -96,6 +106,11 @@ func (p *AlphaProtocolHandler) GetRelationshipHandler(c *gin.Context) {
 	if err != nil {
 		logger.Errorf("Failed to get relationship: %v", err)
 		c.JSON(http.StatusInternalServerError, ErrorMessage("Internal server error"))
+		return
+	}
+
+	if relationship == nil {
+		c.JSON(http.StatusNotFound, ErrorMessage("Not found"))
 		return
 	}
 
@@ -154,6 +169,11 @@ func (p *AlphaProtocolHandler) GetModuleHandler(c *gin.Context) {
 		return
 	}
 
+	if module == nil {
+		c.JSON(http.StatusNotFound, ErrorMessage("Not found"))
+		return
+	}
+
 	c.JSON(http.StatusOK, v0alpha_entity.GetModuleResponse{
 		Module: module,
 	})
@@ -189,6 +209,11 @@ func (p *AlphaProtocolHandler) GetHookHandler(c *gin.Context) {
 		return
 	}
 
+	if hook == nil {
+		c.JSON(http.StatusNotFound, ErrorMessage("Not found"))
+		return
+	}
+
 	c.JSON(http.StatusOK, v0alpha_entity.GetHookResponse{
 		Hook: hook,
 	})
@@ -204,6 +229,11 @@ func (p *AlphaProtocolHandler) GetTransactionHandler(c *gin.Context) {
 		return
 	}
 
+	if transaction == nil {
+		c.JSON(http.StatusNotFound, ErrorMessage("Not found"))
+		return
+	}
+
 	c.JSON(http.StatusOK, v0alpha_entity.GetTransactionResponse{
 		Transaction: transaction,
 	})
@@ -216,6 +246,11 @@ func (p *AlphaProtocolHandler) GetLicenseHandler(c *gin.Context) {
 	if err != nil {
 		logger.Errorf("Failed to get license: %v", err)
 		c.JSON(http.StatusInternalServerError, ErrorMessage("Internal server error"))
+		return
+	}
+
+	if license == nil {
+		c.JSON(http.StatusNotFound, ErrorMessage("Not found"))
 		return
 	}
 

--- a/api/internal/handler/protocol_handler_alpha.go
+++ b/api/internal/handler/protocol_handler_alpha.go
@@ -87,6 +87,7 @@ func (p *AlphaProtocolHandler) ListIpAssetsHandler(c *gin.Context) {
 		requestBody = v0alpha_entity.ListIpAssetsRequest{}
 	}
 
+	logger.Infof("requestBody: %+v", requestBody)
 	ipAssets, err := p.graphServiceAlpha.ListIPAssets(&requestBody.IpOrgId, thegraph.FromRequestQueryOptions(requestBody.Options))
 	if err != nil {
 		logger.Errorf("Failed to get ip assets: %v", err)

--- a/api/internal/handler/protocol_handler_alpha_test.go
+++ b/api/internal/handler/protocol_handler_alpha_test.go
@@ -68,7 +68,7 @@ func TestListIpAssethandler_Success(t *testing.T) {
 		"queryOptions": map[string]interface{}{
 			"pagination": map[string]interface{}{
 				"offset": 0,
-				"limit":  10,
+				"limit":  1,
 			},
 		},
 	})

--- a/api/internal/handler/protocol_handler_alpha_test.go
+++ b/api/internal/handler/protocol_handler_alpha_test.go
@@ -11,8 +11,10 @@ import (
 
 func TestListIpOrgsHandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{
-		"offset": 0,
-		"limit":  10,
+		"pagination": map[string]interface{}{
+			"offset": 0,
+			"limit":  10,
+		},
 	})
 	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
 	ph.ListIpOrgsHandler(c)
@@ -29,6 +31,16 @@ func TestGetIpOrgHandler_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestGetIpOrgHandler_NotFound_Failure(t *testing.T) {
+	c, w := test.MockGin(map[string]interface{}{})
+	c.Params = gin.Params{
+		{Key: "ipOrgId", Value: "0xde493e03d2de0cd7820b4f580beced57296b0011"},
+	}
+	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
+	ph.GetIpOrgHandler(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestGetIpAssetHandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{})
 	c.Params = gin.Params{
@@ -39,12 +51,25 @@ func TestGetIpAssetHandler_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestGetIpAssetHandler_NotFound_Failure(t *testing.T) {
+	c, w := test.MockGin(map[string]interface{}{})
+	c.Params = gin.Params{
+		{Key: "ipAssetId", Value: "10000000"},
+	}
+
+	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
+	ph.GetIpAssetHandler(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestListIpAssethandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{
 		"ipOrgId": "0xde493e03d2de0cd7820b4f580beced57296b0009",
 		"queryOptions": map[string]interface{}{
-			"offset": 0,
-			"limit":  10,
+			"pagination": map[string]interface{}{
+				"offset": 0,
+				"limit":  10,
+			},
 		},
 	})
 	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
@@ -62,6 +87,16 @@ func TestGetRelationshipHandler_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestGetRelationshipHandler_NotFound_Failure(t *testing.T) {
+	c, w := test.MockGin(map[string]interface{}{})
+	c.Params = gin.Params{
+		{Key: "relationshipId", Value: "10000000"},
+	}
+	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
+	ph.GetRelationshipHandler(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestListRelationshipsHandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{
 		"contract": "0x177175a4b26f6ea050676f8c9a14d395f896492c",
@@ -76,8 +111,10 @@ func TestListModulesHandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{
 		"ipOrgId": "0x0000000000000000000000000000000000000000",
 		"queryOptions": map[string]interface{}{
-			"offset": 0,
-			"limit":  10,
+			"pagination": map[string]interface{}{
+				"offset": 0,
+				"limit":  10,
+			},
 		},
 	})
 	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
@@ -95,12 +132,24 @@ func TestGetModuleHandler_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestGetModuleHandler_NotFound_Failure(t *testing.T) {
+	c, w := test.MockGin(map[string]interface{}{})
+	c.Params = gin.Params{
+		{Key: "moduleId", Value: "0x091e5f55135155bb8cb5868adb39e5c34eb32cfe"},
+	}
+	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
+	ph.GetModuleHandler(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestListHooksHandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{
 		"moduleId": "0x091e5f55135155bb8cb5868adb39e5c34eb32cfd",
 		"queryOptions": map[string]interface{}{
-			"offset": 0,
-			"limit":  10,
+			"pagination": map[string]interface{}{
+				"offset": 0,
+				"limit":  10,
+			},
 		},
 	})
 	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
@@ -118,6 +167,16 @@ func TestGetHookHandler_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestGetHookHandler_NotFound_Failure(t *testing.T) {
+	c, w := test.MockGin(map[string]interface{}{})
+	c.Params = gin.Params{
+		{Key: "hookId", Value: "0xc0f6e387ac0b324ec18eacf22ee7271207dce2d5"},
+	}
+	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
+	ph.GetHookHandler(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestGetTransactionHandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{})
 	c.Params = gin.Params{
@@ -126,6 +185,16 @@ func TestGetTransactionHandler_Success(t *testing.T) {
 	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
 	ph.GetTransactionHandler(c)
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestGetTransactionHandler_NotFound_Failure(t *testing.T) {
+	c, w := test.MockGin(map[string]interface{}{})
+	c.Params = gin.Params{
+		{Key: "transactionId", Value: "0x158f74772af1bf9e5d1eb9d6633bb6a602eea97bbbd552b16696d7d2d3fa007703000001"},
+	}
+	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
+	ph.GetTransactionHandler(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestGetLicenseHandler_Success(t *testing.T) {
@@ -138,13 +207,25 @@ func TestGetLicenseHandler_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestGetLicenseHandler_NotFound_Failure(t *testing.T) {
+	c, w := test.MockGin(map[string]interface{}{})
+	c.Params = gin.Params{
+		{Key: "licenseId", Value: "10000000"},
+	}
+	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
+	ph.GetLicenseHandler(c)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestListLicensesHandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{
 		"ipOrgId":   "0xb422e54932c1dae83e78267a4dd2805aa64a8061",
 		"ipAssetId": "0",
 		"queryOptions": map[string]interface{}{
-			"offset": 0,
-			"limit":  10,
+			"pagination": map[string]interface{}{
+				"offset": 0,
+				"limit":  10,
+			},
 		},
 	})
 	ph := NewAlphaProtocolHandler(test.CreateTheGraphServiceAlpha())
@@ -156,8 +237,10 @@ func TestListTransactionsHandler_Success(t *testing.T) {
 	c, w := test.MockGin(map[string]interface{}{
 		"ipOrgId": "0xde493e03d2de0cd7820b4f580beced57296b0009",
 		"queryOptions": map[string]interface{}{
-			"offset": 0,
-			"limit":  10,
+			"pagination": map[string]interface{}{
+				"offset": 0,
+				"limit":  10,
+			},
 		},
 	})
 

--- a/api/internal/service/thegraph/alphaImpl_test.go
+++ b/api/internal/service/thegraph/alphaImpl_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/machinebox/graphql"
+	"github.com/project-nova/backend/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -114,6 +115,17 @@ func TestListIPAssets_WithIpOrgId_Success(t *testing.T) {
 	assert.True(t, len(ipAssets) > 0)
 }
 
+func TestListIPAssets_WithIpOrgId_WithLimit_Success(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	ipOrgId := IP_ORG_ID
+	ipAssets, err := service.ListIPAssets(&ipOrgId, &TheGraphQueryOptions{
+		First: 2,
+		Skip:  0,
+	})
+	assert.Nil(t, err)
+	assert.True(t, len(ipAssets) == 2)
+}
+
 func TestListIPAssets_WithoutIpOrgId_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	ipAssets, err := service.ListIPAssets(nil, nil)
@@ -124,6 +136,7 @@ func TestListIPAssets_WithoutIpOrgId_Success(t *testing.T) {
 func TestGetIPAsset_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	ipAsset, err := service.GetIPAsset("1")
+	logger.Infof("ipAsset: %+v", ipAsset)
 	assert.Nil(t, err)
 	assert.True(t, ipAsset.ID == "1")
 	assert.True(t, ipAsset.CreatedAt == "2023-11-19T18:46:24Z")

--- a/api/internal/service/thegraph/alphaImpl_test.go
+++ b/api/internal/service/thegraph/alphaImpl_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/machinebox/graphql"
+	"github.com/project-nova/backend/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,10 +28,18 @@ func TestListIPOrgs_Success(t *testing.T) {
 func TestGetIPOrgs_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	iporg, err := service.GetIPOrg("0xde493e03d2de0cd7820b4f580beced57296b0009")
-
+	logger.Infof("iporg: %v", iporg)
 	assert.Nil(t, err)
 	assert.NotNil(t, iporg)
 	assert.True(t, iporg.ID == "0xde493e03d2de0cd7820b4f580beced57296b0009")
+	assert.True(t, iporg.CreatedAt == "2023-11-18T06:44:12Z")
+}
+
+func TestGetIPOrgs_NotFound_Failure(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	iporg, err := service.GetIPOrg("0xde493e03d2de0cd7820b4f580beced57296b0011")
+	assert.Nil(t, err)
+	assert.Nil(t, iporg)
 }
 
 func TestListRelationships_MatchSource_Success(t *testing.T) {
@@ -38,6 +47,7 @@ func TestListRelationships_MatchSource_Success(t *testing.T) {
 	relationships, err := service.ListRelationships("0x177175a4b26f6ea050676f8c9a14d395f896492c", "4", nil)
 	assert.Nil(t, err)
 	assert.True(t, len(relationships) > 0)
+	assert.True(t, relationships[0].RegisteredAt == "2023-11-22T03:37:48Z")
 }
 
 func TestListRelationships_MatchDestination_Success(t *testing.T) {
@@ -47,11 +57,26 @@ func TestListRelationships_MatchDestination_Success(t *testing.T) {
 	assert.True(t, len(relationships) > 0)
 }
 
+func TestListRelationships_NotMatch_Failure(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	relationships, err := service.ListRelationships("0x177175a4b26f6ea050676f8c9a14d395f896492c", "51", nil)
+	assert.Nil(t, err)
+	assert.True(t, len(relationships) == 0)
+}
+
 func TestGetRelationshipHandler_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	relationship, err := service.GetRelationship("1")
 	assert.Nil(t, err)
 	assert.True(t, relationship.ID == "0x99d5736c65bd81cd4a361a731d4a035375a0926c95e4132e8fcb80ad5b602b5c28000000")
+	assert.True(t, relationship.RegisteredAt == "2023-11-19T22:10:48Z")
+}
+
+func TestGetRelationshipHandler_NotFound_Failure(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	relationship, err := service.GetRelationship("123123")
+	assert.Nil(t, err)
+	assert.Nil(t, relationship)
 }
 
 func TestListModules_WithIpOrgId_Success(t *testing.T) {
@@ -76,6 +101,13 @@ func TestGetModule_Success(t *testing.T) {
 	assert.True(t, module.ModuleKey == "LICENSING_MODULE")
 }
 
+func TestGetModule_NotFound_Failure(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	module, err := service.GetModule("0xa906e2589a7f8385a376babbb70a39dad551604b")
+	assert.Nil(t, err)
+	assert.Nil(t, module)
+}
+
 func TestListIPAssets_WithIpOrgId_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	ipOrgId := IP_ORG_ID
@@ -96,6 +128,14 @@ func TestGetIPAsset_Success(t *testing.T) {
 	ipAsset, err := service.GetIPAsset("1")
 	assert.Nil(t, err)
 	assert.True(t, ipAsset.ID == "0x158f74772af1bf9e5d1eb9d6633bb6a602eea97bbbd552b16696d7d2d3fa007703000000")
+	assert.True(t, ipAsset.CreatedAt == "2023-11-19T18:46:24Z")
+}
+
+func TestGetIPAsset_NotFound_Failure(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	ipAsset, err := service.GetIPAsset("12312")
+	assert.Nil(t, err)
+	assert.Nil(t, ipAsset)
 }
 
 func TestListTransactions_WithIpOrgId_Success(t *testing.T) {
@@ -118,6 +158,14 @@ func TestGetTransaction_Success(t *testing.T) {
 	transaction, err := service.GetTransaction("0x158f74772af1bf9e5d1eb9d6633bb6a602eea97bbbd552b16696d7d2d3fa007703000000")
 	assert.Nil(t, err)
 	assert.True(t, transaction.ID == "0x158f74772af1bf9e5d1eb9d6633bb6a602eea97bbbd552b16696d7d2d3fa007703000000")
+	assert.True(t, transaction.CreatedAt == "2023-11-19T18:46:24Z")
+}
+
+func TestGetTransaction_Failure(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	transaction, err := service.GetTransaction("0x158f74772af1bf9e5d1eb9d6633bb6a602eea97bbbd552b16696d7d1d3fa007703000000")
+	assert.Nil(t, err)
+	assert.Nil(t, transaction)
 }
 
 func TestListHooks_WithModuleID_Success(t *testing.T) {
@@ -140,6 +188,15 @@ func TestGetHook_Success(t *testing.T) {
 	hook, err := service.GetHook("0xc0f6e387ac0b324ec18eacf22ee7271207dce3d5")
 	assert.Nil(t, err)
 	assert.True(t, hook.ID == "0xc0f6e387ac0b324ec18eacf22ee7271207dce3d5")
+	assert.True(t, hook.RegisteredAt == "2023-11-18T06:44:24Z")
+
+}
+
+func TestGetHook_NotFound_Failure(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	hook, err := service.GetHook("0xc0f6e387ac0b324ec18eacf22ee7271207dce2d5")
+	assert.Nil(t, err)
+	assert.Nil(t, hook)
 }
 
 func TestListLicenses_WithIpOrgIdAndIpAssetId_Success(t *testing.T) {
@@ -179,4 +236,12 @@ func TestGetLicense_Success(t *testing.T) {
 	license, err := service.GetLicense("1")
 	assert.Nil(t, err)
 	assert.True(t, license.ID == "0x3f6aa75c359baf4af470aaf63cb7a10e6840c07c5a3a5d96144966d9fd7b27cf16000000")
+	assert.True(t, license.CreatedAt == "2023-11-21T02:20:24Z")
+}
+
+func TestGetLicense_NotFound_Failure(t *testing.T) {
+	service := CreateTheGraphServiceAlpha()
+	license, err := service.GetLicense("1123")
+	logger.Info(license)
+	assert.Nil(t, err)
 }

--- a/api/internal/service/thegraph/alphaImpl_test.go
+++ b/api/internal/service/thegraph/alphaImpl_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/machinebox/graphql"
-	"github.com/project-nova/backend/pkg/logger"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +27,6 @@ func TestListIPOrgs_Success(t *testing.T) {
 func TestGetIPOrgs_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	iporg, err := service.GetIPOrg("0xde493e03d2de0cd7820b4f580beced57296b0009")
-	logger.Infof("iporg: %v", iporg)
 	assert.Nil(t, err)
 	assert.NotNil(t, iporg)
 	assert.True(t, iporg.ID == "0xde493e03d2de0cd7820b4f580beced57296b0009")
@@ -67,7 +65,6 @@ func TestListRelationships_NotMatch_Failure(t *testing.T) {
 func TestGetRelationshipHandler_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	relationship, err := service.GetRelationship("1")
-	logger.Infof("relationship: %+v", relationship)
 	assert.Nil(t, err)
 	assert.True(t, relationship.ID == "1")
 	assert.True(t, relationship.RegisteredAt == "2023-11-19T22:10:48Z")
@@ -113,7 +110,6 @@ func TestListIPAssets_WithIpOrgId_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	ipOrgId := IP_ORG_ID
 	ipAssets, err := service.ListIPAssets(&ipOrgId, nil)
-	logger.Infof("ipAssets: %+v", ipAssets)
 	assert.Nil(t, err)
 	assert.True(t, len(ipAssets) > 0)
 }
@@ -129,7 +125,7 @@ func TestGetIPAsset_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	ipAsset, err := service.GetIPAsset("1")
 	assert.Nil(t, err)
-	assert.True(t, ipAsset.ID == "0x158f74772af1bf9e5d1eb9d6633bb6a602eea97bbbd552b16696d7d2d3fa007703000000")
+	assert.True(t, ipAsset.ID == "1")
 	assert.True(t, ipAsset.CreatedAt == "2023-11-19T18:46:24Z")
 }
 
@@ -237,13 +233,13 @@ func TestGetLicense_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	license, err := service.GetLicense("1")
 	assert.Nil(t, err)
-	assert.True(t, license.ID == "0x3f6aa75c359baf4af470aaf63cb7a10e6840c07c5a3a5d96144966d9fd7b27cf16000000")
+	assert.True(t, license.ID == "1")
 	assert.True(t, license.CreatedAt == "2023-11-21T02:20:24Z")
 }
 
 func TestGetLicense_NotFound_Failure(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	license, err := service.GetLicense("1123")
-	logger.Info(license)
 	assert.Nil(t, err)
+	assert.Nil(t, license)
 }

--- a/api/internal/service/thegraph/alphaImpl_test.go
+++ b/api/internal/service/thegraph/alphaImpl_test.go
@@ -67,8 +67,9 @@ func TestListRelationships_NotMatch_Failure(t *testing.T) {
 func TestGetRelationshipHandler_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	relationship, err := service.GetRelationship("1")
+	logger.Infof("relationship: %+v", relationship)
 	assert.Nil(t, err)
-	assert.True(t, relationship.ID == "0x99d5736c65bd81cd4a361a731d4a035375a0926c95e4132e8fcb80ad5b602b5c28000000")
+	assert.True(t, relationship.ID == "1")
 	assert.True(t, relationship.RegisteredAt == "2023-11-19T22:10:48Z")
 }
 
@@ -112,6 +113,7 @@ func TestListIPAssets_WithIpOrgId_Success(t *testing.T) {
 	service := CreateTheGraphServiceAlpha()
 	ipOrgId := IP_ORG_ID
 	ipAssets, err := service.ListIPAssets(&ipOrgId, nil)
+	logger.Infof("ipAssets: %+v", ipAssets)
 	assert.Nil(t, err)
 	assert.True(t, len(ipAssets) > 0)
 }

--- a/api/internal/service/thegraph/interface.go
+++ b/api/internal/service/thegraph/interface.go
@@ -60,12 +60,12 @@ func FromRequestQueryOptions(options *v0alpha.QueryOptions) *TheGraphQueryOption
 		}
 	}
 
-	if options.Limit == 0 {
-		options.Limit = 100
+	if options.Pagination.Limit == 0 {
+		options.Pagination.Limit = 100
 	}
 
 	return &TheGraphQueryOptions{
-		First: options.Limit,
-		Skip:  options.Offset,
+		First: options.Pagination.Limit,
+		Skip:  options.Pagination.Offset,
 	}
 }

--- a/pkg/utils/timeutils.go
+++ b/pkg/utils/timeutils.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"strconv"
+	"time"
+)
+
+func TimestampInSecondsToISO8601(timestamp string) string {
+	blockTimestamp, _ := strconv.ParseInt(timestamp, 10, 64)
+	return time.Unix(blockTimestamp, 0).UTC().Format(time.RFC3339)
+}


### PR DESCRIPTION
1. fixed structure of QueryOptions and added `pagination` key
2. return 404 not found with error message "Not found" if an entity can't be found from the graph
3. return ISO8601 format for all timestamps
4. fixed marshal error for ipasset